### PR TITLE
7.x grammar fixes

### DIFF
--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -103,7 +103,7 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
     return array(
       'nothing' => array(
         '#type' => 'item',
-        '#value' => t('This importer does not define a form...  This is a problem.'),
+        '#value' => t('Warning: this importer does not define a form'),
       ),
     );
   }
@@ -356,7 +356,7 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
     }
     else {
       $errors[] = array(
-        t('Failed to produce MODS for @pid.'),
+        t('Failed to produce MODS record for @pid.'),
       );
     }
 
@@ -375,7 +375,7 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
     }
     else {
       $errors[] = array(
-        t('Failed to produce DC for @pid.'),
+        t('Failed to produce DC record for @pid.'),
       );
     }
 
@@ -435,7 +435,7 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
       }
 
       $to_return[] = array(
-        t('There seem to have been issues ingesting "%title" as %pid.'),
+        t('Error ingesting "%title" as %pid.'),
         array(
           '%pid' => $pid,
           '%title' => $this->getTitle()),

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -58,10 +58,10 @@ class ZipBatchImporter extends IslandoraBatchImporter {
       'fs' => array(
         '#type' => 'fieldset',
         '#title' => t('Zip Batch Importer'),
-        '#description' => t('Select the file containing the assets and metadata to import. Assets and metadata will be matched together based on the portion of the filename without the extension, so my_file.xml and my_file.pdf will be combined into a single object.'),
+        '#description' => t('Select the file containing the assets and metadata to import. Assets and metadata will be matched together based on the portion of the filename without the extension - e.g. my_file.xml and my_file.pdf would be combined into a single object.'),
         'file' => array(
           '#type' => 'managed_file',
-          '#title' => t('Zip file of files to import'),
+          '#title' => t('Zip file containing files to import'),
           '#upload_validators' => array(
             'file_validate_extensions' => array('zip'),
           ),
@@ -98,7 +98,7 @@ class ZipBatchImporter extends IslandoraBatchImporter {
    */
   public static function readyForBatch(array &$form_state) {
     if (empty($form_state['values']['file'])) {
-      form_set_error('file', t('Need a zip file!'));
+      form_set_error('file', t('Need a Zip file!'));
     }
 
     $content_models = array_filter($form_state['values']['content_model']);

--- a/modules/zip_importer/zip_importer.module
+++ b/modules/zip_importer/zip_importer.module
@@ -23,12 +23,13 @@ function zip_importer_islandora_importer() {
 function zip_importer_help($path, $args) {
   if ($path == 'islandora/object/%islandora_object/manage/collection/batch_import') {
     return '<p>' . t('The "ZIP File Importer" allows for batch imports in a very similar manner
-      as the batch ingester of Drupal 6, where a zip file could be uploaded, and objects created
-      based on the names of the files contained.  The files are grouped by dropping the extension,
-      so "my_file.xml" and "my_file.pdf" will be used to create a single object.  Currently,
-      the XML files can contain MODS, MARCXML or DC (in no XML is given, basic MODS (and DC)
-      will be generated with just the base filename).  For other files, we try to match mimetypes
-      against those declared for datastreams in the selected content model\'s "DS-COMPOSITE" stream.') .
+      to the Drupal 6 batch ingester, where a zip file could be uploaded and objects created
+      based on the names of the files contained. The files are grouped by dropping the extension,
+      so "my_file.xml" and "my_file.pdf" would be used to create a single object. Currently,
+      the XML files can contain MODS, MARCXML or DC metadata; if no XML is given, basic MODS
+      (and DC) metadata will be generated with just the base filename. For other files, we try
+      to match mimetypes against those declared for datastreams in the selected content model\'s
+      "DS-COMPOSITE" stream.') .
     '</p>';
   }
 }


### PR DESCRIPTION
Mainly editing for clarity and style refinements. A few misspellings as well, plus double spaces. Zip format is always spelled as such, never ZIP or zip. 
