### PR TITLE
Miscellaneous fixes and improvements...

### DIFF
--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -413,7 +413,7 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
    *   - An integer representing a watchdog error level
    *   - A string containing a rendered link.
    */
-  public function writeToFedora($pid, $parent_pid = NULL, &$sandbox) {
+  public function writeToFedora($pid, $parent_pid, &$sandbox) {
     // An array of arrays, containing a structure describing error
     // conditions.
     // - A translated string

--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -317,7 +317,7 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
    */
   public function getDC() {
     if ($this->dc === NULL) {
-      $new_dc = self::runXSLTransform(array(
+      $new_dc = static::runXSLTransform(array(
                   'xsl' => drupal_get_path('module', 'islandora_importer') . '/xsl/mods_to_dc.xsl',
                   'input' => $this->getMODS(),
                 ));

--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -122,12 +122,12 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
    * @return string
    *   An identifier for the repo.
    */
-  protected function getIdentifier(IslandoraTuque $tuque) {
+  protected function getIdentifier(IslandoraTuque $tuque, $namespace) {
     if (empty($this->context['results']['pid_cache'])) {
       // Get enough PIDs for half of the remaining items.
       // (plus one, so we'll always get at least one).
       $this->context['results']['pid_cache'] = (array) $tuque->api->m->getNextPid(
-        $item->pidNamespace,
+        $namespace,
         intval((($this->context['sandbox']['max'] - $this->context['sandbox']['progress']) / 2) + 1)
       );
     }
@@ -172,9 +172,9 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
 
       $result = NULL;
       if ($item) {
-        $pid = $this->getIdentifier($tuque);
+        $pid = $this->getIdentifier($tuque, $item->pidNamespace);
 
-        $results = $item->writeToFedora($pid, $this->parentPid);
+        $results = $item->writeToFedora($pid, $this->parentPid, $this->context['sandbox']);
 
         $this->context['results'] = array_merge($this->context['results'], $results);
       }
@@ -395,8 +395,25 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
 
   /**
    * Write this item to Fedora.
+   *
+   * @param string $pid
+   *   A PID to we can use to which to write our object.
+   * @param string $parent_pid
+   *   The parent to whom we should relate our object.
+   * @param array $sandbox
+   *   A reference to the batch $context['sandbox'], so we can pass information
+   *   around a little more easily (e.g. for reporting).
+   *
+   * @return array
+   *   An array of arrays, each with up to four values:
+   *   - A string containing a message which will be passed to format_string()
+   *     and in the watchdog.
+   *   - An associative array of placeholders, as used by format_string() and
+   *     watchdog, to use in the message.
+   *   - An integer representing a watchdog error level
+   *   - A string containing a rendered link.
    */
-  public function writeToFedora($pid, $parent_pid = NULL) {
+  public function writeToFedora($pid, $parent_pid = NULL, &$sandbox) {
     // An array of arrays, containing a structure describing error
     // conditions.
     // - A translated string

--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -117,6 +117,25 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
   public abstract function getNumber();
 
   /**
+   * Get an identifier.
+   *
+   * @return string
+   *   An identifier for the repo.
+   */
+  protected function getIdentifier(IslandoraTuque $tuque) {
+    if (empty($this->context['results']['pid_cache'])) {
+      // Get enough PIDs for half of the remaining items.
+      // (plus one, so we'll always get at least one).
+      $this->context['results']['pid_cache'] = (array) $tuque->api->m->getNextPid(
+        $item->pidNamespace,
+        intval((($this->context['sandbox']['max'] - $this->context['sandbox']['progress']) / 2) + 1)
+      );
+    }
+
+    return array_shift($this->context['results']['pid_cache']);
+  }
+
+  /**
    * Loop import until we have used up 1/3 of the max execution time.
    */
   public function runBatch() {
@@ -153,15 +172,7 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
 
       $result = NULL;
       if ($item) {
-        if (empty($this->context['results']['pid_cache'])) {
-          // Get enough PIDs for half of the remaining items.
-          // (plus one, so we'll always get at least one).
-          $this->context['results']['pid_cache'] = (array) $tuque->api->m->getNextPid(
-            $item->pidNamespace,
-            intval((($this->context['sandbox']['max'] - $this->context['sandbox']['progress']) / 2) + 1)
-          );
-        }
-        $pid = array_shift($this->context['results']['pid_cache']);
+        $pid = $this->getIdentifier();
 
         $results = $item->writeToFedora($pid, $this->parentPid);
 
@@ -386,8 +397,6 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
    * Write this item to Fedora.
    */
   public function writeToFedora($pid, $parent_pid = NULL) {
-    global $user;
-
     // An array of arrays, containing a structure describing error
     // conditions.
     // - A translated string
@@ -401,9 +410,6 @@ abstract class IslandoraImportObject implements IslandoraImportObjectInterface {
     $label = $this->getTitle();
     $datastreams = $this->getDatastreams($to_return, $files);
     $relationships = array();
-    $collection_pid = NULL;
-
-    $files = array();
 
     $content_models = array_unique((array) $this->contentModel);
 

--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -172,7 +172,7 @@ abstract class IslandoraBatchImporter implements IslandoraBatchImporterInterface
 
       $result = NULL;
       if ($item) {
-        $pid = $this->getIdentifier();
+        $pid = $this->getIdentifier($tuque);
 
         $results = $item->writeToFedora($pid, $this->parentPid);
 

--- a/islandora_importer.module
+++ b/islandora_importer.module
@@ -240,8 +240,8 @@ function islandora_importer_batch_finished($success, array $results, array $ops)
     unset($results['pid_cache']);
     unset($results['islandora_importer']);
 
-    $filename = file_create_filename('batch_import_results.html', 'public://');
-    $file = fopen($filename, 'w');
+    $file_object = file_save_data('', 'public://batch_import_results.html');
+    $file = fopen($file_object->uri, 'w');
     fwrite($file, '<html><body><ol>');
     $levels = watchdog_severity_levels();
     foreach ($results as $result) {
@@ -264,15 +264,20 @@ function islandora_importer_batch_finished($success, array $results, array $ops)
     fwrite($file, '</ol></body></html>');
     fclose($file);
 
+    // Make the file temporary, so it should get deleted when the cron job is
+    // run after 6 hours.
+    $file_object->status = 0;
+    file_save($file_object);
+
     if (user_access('access site reports')) {
       drupal_set_message(t('Batch complete!  View/Download !results or see the !watchdog for details.', array(
-        '!results' => l(t('simple results'), file_create_url($filename)),
+        '!results' => l(t('simple results'), file_create_url($file_object->uri)),
         '!watchdog' => l(t('watchdog log'), 'admin/reports/dblog'),
       )), 'info');
     }
     else {
       drupal_set_message(t('Batch complete!  View/Download !results.', array(
-        '!results' => l(t('simple results'), file_create_url($filename)),
+        '!results' => l(t('simple results'), file_create_url($file_object->uri)),
       )), 'info');
     }
   }

--- a/islandora_importer.module
+++ b/islandora_importer.module
@@ -254,8 +254,8 @@ function islandora_importer_batch_finished($success, array $results, array $ops)
         $result[3] :
         '';
 
-      fwrite($file, '<li>' . $levels[$level] . ': ' . t($message, $subs) . ((!empty($link)) ?
-        ('  ' . t('Link: !link.', array('!link' => $link))) :
+      fwrite($file, '<li>' . $levels[$level] . ': ' . format_string($message, $subs) . ((!empty($link)) ?
+        ('  ' . format_string('Link: !link.', array('!link' => $link))) :
         '') . "</li>");
 
       array_unshift($result, 'islandora_importer');
@@ -270,18 +270,20 @@ function islandora_importer_batch_finished($success, array $results, array $ops)
     file_save($file_object);
 
     if (user_access('access site reports')) {
-      drupal_set_message(t('Batch complete!  View/Download !results or see the !watchdog for details.', array(
+      drupal_set_message(format_xss(t('Batch complete!  View/Download !results or see the !watchdog for details.', array(
         '!results' => l(t('simple results'), file_create_url($file_object->uri)),
         '!watchdog' => l(t('watchdog log'), 'admin/reports/dblog'),
-      )), 'info');
+      ))), 'info');
     }
     else {
-      drupal_set_message(t('Batch complete!  View/Download !results.', array(
+      drupal_set_message(format_xss(t('Batch complete!  View/Download !results.', array(
         '!results' => l(t('simple results'), file_create_url($file_object->uri)),
-      )), 'info');
+      ))), 'info');
     }
   }
   else {
-    drupal_set_message("Failed operations: " . print_r($ops, TRUE), 'error');
+    drupal_set_message(t('Failed operations: @ops', array(
+      '@ops' => print_r($ops, TRUE),
+    )), 'error');
   }
 }

--- a/islandora_importer.module
+++ b/islandora_importer.module
@@ -270,13 +270,13 @@ function islandora_importer_batch_finished($success, array $results, array $ops)
     file_save($file_object);
 
     if (user_access('access site reports')) {
-      drupal_set_message(format_xss(t('Batch complete!  View/Download !results or see the !watchdog for details.', array(
+      drupal_set_message(filter_xss(t('Batch complete!  View/Download !results or see the !watchdog for details.', array(
         '!results' => l(t('simple results'), file_create_url($file_object->uri)),
         '!watchdog' => l(t('watchdog log'), 'admin/reports/dblog'),
       ))), 'info');
     }
     else {
-      drupal_set_message(format_xss(t('Batch complete!  View/Download !results.', array(
+      drupal_set_message(filter_xss(t('Batch complete!  View/Download !results.', array(
         '!results' => l(t('simple results'), file_create_url($file_object->uri)),
       ))), 'info');
     }

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -126,7 +126,7 @@ class ZipBatchImporter extends IslandoraBatchImporter {
       'file' => $file,
       'pid_namespace' => $form_state['values']['namespace'],
       'content_model' => $content_models,
-      'object_info' => self::getIngestInfo($file),
+      'object_info' => static::getIngestInfo($file),
       'processed_objects' => array(),
     );
     return $info;
@@ -201,7 +201,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     $key = key($info['object_info']);
     $record['object_info'] = $info['processed_objects'][$key] = $info['object_info'][$key];
     unset($info['object_info'][$key]);
-    return (empty($record) ? FALSE : new self($record));
+    return (empty($record) ? FALSE : new static($record));
   }
 
   /**
@@ -323,14 +323,14 @@ class ZipBatchImportObject extends IslandoraImportObject {
           }
           // MARCXML, transform to MODS and set.
           elseif ($s_xml->getName() == 'record') {
-            $this->mods = self::runXSLTransform(array(
+            $this->mods = static::runXSLTransform(array(
                   'input' => $xml,
                   'xsl' => drupal_get_path('module', 'zip_importer') . '/xsl/MARC21slim2MODS3-4.xsl',
                 ));
           }
           // DC, transform to MODS and set.
           elseif ($s_xml->getName() == 'dc') {
-            $this->mods = self::runXSLTransform(array(
+            $this->mods = static::runXSLTransform(array(
                   'input' => $xml,
                   'xsl' => drupal_get_path('module', 'zip_importer') . '/xsl/simpleDC2MODS.xsl',
                 ));

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -207,6 +207,9 @@ class ZipBatchImportObject extends IslandoraImportObject {
   /**
    * Determine the datastream ID for the given file.
    *
+   * Gets info from the DS-COMPOSITE-MODELs for the selected content models
+   * and attempts to match based on detected MIME-Types.
+   *
    * @param string $name
    *   A filename for which to determine a mimetype.
    *
@@ -220,10 +223,12 @@ class ZipBatchImportObject extends IslandoraImportObject {
     // Something like this would be nice to have...  Need a way to indicate
     // primary assets, though...  Think about basic image, where the content
     // model can contain "OBJ" image/jpeg, "TN" image/jpeg and so on...
-    static $mime_detect = new MimeDetect();
+    static $mime_detect = NULL;
     static $dsids = NULL;
 
-    if ($dsids === NULL) {
+   if ($mime_detect === NULL || $dsids === NULL) {
+      $mime_detect = new MimeDetect();
+
       module_load_include('inc', 'islandora', 'includes/utilities');
       $models = (array) $this->source['content_model'];
       $dsids = islandora_get_datastreams_requirements_from_models($models);
@@ -265,10 +270,14 @@ class ZipBatchImportObject extends IslandoraImportObject {
       list($dsid, $mimetype) = $this->determineDSIDAndMimetype($name);
 
       if (!$dsid) {
-        drupal_set_message(t('The detected mimetype of %filename (@mime) is not supported by any of the selected content models.', array(
-          '@mime' => $mimetype,
-          '%filename' => $name,
-        )), 'warning', FALSE);
+        $errors[] = array(
+          t('The detected mimetype of %filename (@mime) is not supported by any of the selected content models.'),
+          array(
+            '@mime' => $mimetype,
+            '%filename' => $name,
+          ),
+          WATCHDOG_ERROR,
+        );
         continue;
       }
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -207,38 +207,41 @@ class ZipBatchImportObject extends IslandoraImportObject {
   /**
    * Determine the datastream ID for the given file.
    *
-   * @return string
-   *   The string 'OBJ'. Was trying to match the mimetype against what the
-   *   DS-COMPOSITE-MODEL indicates is valid...  Some issues, though... See the
-   *   in-code comments for a bit more info.
+   * @param string $name
+   *   A filename for which to determine a mimetype.
+   *
+   * @return array
+   *   An array containing two values:
+   *   - Either boolean FALSE or the datastream ID, as mapped in the
+   *     DS-COMPOSITE-MODELs of the selected object.
+   *   - A string containing the detected mimetype of the file.
    */
-  protected function determineDSID($name, $extension) {
+  protected function determineDSIDAndMimetype($name) {
     // Something like this would be nice to have...  Need a way to indicate
     // primary assets, though...  Think about basic image, where the content
     // model can contain "OBJ" image/jpeg, "TN" image/jpeg and so on...
-    //
-    // static $mime_detect = new MimeDetect(),
-    // $dsids = NULL;
-    //
-    // if ($dsids === NULL) {
-    // module_load_include('inc', 'islandora', 'includes/utilities');
-    // $models = (array)$this->source['content_model'];
-    // $dsids = islandora_get_datastreams_requirements_from_models($models);
-    // }
-    //
+    static $mime_detect = new MimeDetect();
+    static $dsids = NULL;
+
+    if ($dsids === NULL) {
+      module_load_include('inc', 'islandora', 'includes/utilities');
+      $models = (array) $this->source['content_model'];
+      $dsids = islandora_get_datastreams_requirements_from_models($models);
+    }
+
+    $mimetype = $mime_detect->getMimetype($name);
+
+    $dsid = FALSE;
     // Determine which stream this should be...  Uses the first matching, as
-    // as received from the DC-COMPOSITE.
-    // $mimetype = $mime_detect->getMimetype($name);
-    //
-    // $dsid = strtoupper($extension);
-    // foreach ($dsids as $ds => $info) {
-    // if (in_array($mimetype, $info['mime'])) {
-    // $dsid = $ds;
-    // break;
-    // }
-    // }
-    // return $dsid;
-    return 'OBJ';
+    // received from the DC-COMPOSITE.
+    foreach ($dsids as $ds => $info) {
+      if (in_array($mimetype, $info['mime'])) {
+        $dsid = $ds;
+        break;
+      }
+    }
+
+    return array($dsid, $mimetype);
   }
 
   /**
@@ -249,9 +252,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected function getDatastreams(&$errors = NULL, &$files = NULL) {
     module_load_include('inc', 'islandora', 'includes/utilities');
     $to_return = parent::getDatastreams($errors, $files);
-    $mime_detect = new MimeDetect();
-    $mappings = $this->getDSComp();
-    $dsids = islandora_get_datastreams_requirements_from_models((array) $this->source['content_model']);
 
     foreach ($this->source['object_info'] as $datastream => $name) {
       if ($datastream == 'xml') {
@@ -262,17 +262,15 @@ class ZipBatchImportObject extends IslandoraImportObject {
 
       // Determine which stream this should be...  Uses the first matching, as
       // as received from the DC-COMPOSITE.
-      $mimetype = $mime_detect->getMimetype($name);
+      list($dsid, $mimetype) = $this->determineDSIDAndMimetype($name);
 
-      if (!isset($mappings[$mimetype])) {
-        drupal_set_message(t('@mime not supported by this @content', array('@mime' => $mimetype, '@content' => $this->source['content_model'])), 'warning', FALSE);
+      if (!$dsid) {
+        drupal_set_message(t('The detected mimetype of %filename (@mime) is not supported by any of the selected content models.', array(
+          '@mime' => $mimetype,
+          '%filename' => $name,
+        )), 'warning', FALSE);
         continue;
       }
-
-      // Using mapping allows us to map more thna OBJ. Will not work for Content
-      // Models with more than one datastream with the same mimetype other
-      // import modules would be better suited for those content models.
-      $dsid = $mappings[$mimetype];
 
       $zip = new ZipArchive();
       $zip->open(drupal_realpath($this->source['file']->uri));
@@ -292,10 +290,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
         );
       }
       $zip->close();
-
-      // XXX: If multiple assets were currently possible, this "break" would
-      // not be valid.
-      // break;
     }
 
     return $to_return;
@@ -392,30 +386,4 @@ EOXML;
 
     return $this->dc;
   }
-
-  /**
-   * Populates mapping array with mimetype/DSID pairs.
-   *
-   * @return array
-   *   Mimetype to DSID Mapping.
-   */
-  public function getDSComp() {
-    $content_models = $this->contentModel;
-    reset($content_models);
-    $content_model = key($content_models);
-    $cm_object = islandora_object_load($content_model);
-    $datastream = $cm_object['DS-COMPOSITE-MODEL'];
-    $ds_comp_stream = $datastream->content;
-    $sxml = new SimpleXMLElement($ds_comp_stream);
-    $mappings = array();
-    foreach ($sxml->dsTypeModel as $ds) {
-      foreach ($ds->form as $form) {
-        $mime = (string) $form['MIME'];
-        $dsid = (string) $ds['ID'];
-        $mappings[$mime] = $dsid;
-      }
-    }
-    return $mappings;
-  }
-
 }

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -226,7 +226,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     static $mime_detect = NULL;
     static $dsids = NULL;
 
-   if ($mime_detect === NULL || $dsids === NULL) {
+    if ($mime_detect === NULL || $dsids === NULL) {
       $mime_detect = new MimeDetect();
 
       module_load_include('inc', 'islandora', 'includes/utilities');

--- a/modules/zip_importer/zip_importer.module
+++ b/modules/zip_importer/zip_importer.module
@@ -33,4 +33,3 @@ function zip_importer_help($path, $args) {
     '</p>';
   }
 }
-


### PR DESCRIPTION
- Break PID generation out to separate method, so it may be more easily overridden
- Pass along `$context['sandbox']`, so that data can be carried and used in later iterations through the batch operation
- Squash the custom DS-COMPOSITE-MODEL parsing
