### PR TITLE
Fixed content type name handling to accomadate audio model

### DIFF
--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -255,7 +255,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     // Fire off to the dirivitve hook to get the primary dsid's.
     $hook_output = array();
     foreach ($models as $key => $value) {
-      $model_name_replacements = array(":","-");
+      $model_name_replacements = array(':', '-');
       $lowered_model = strtolower(str_replace($model_name_replacements, "_", $value));
       // Invoke _islandora_derivative hook for primary DSID's.
       $data = module_invoke_all("$lowered_model" . '_islandora_derivative');

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -255,7 +255,8 @@ class ZipBatchImportObject extends IslandoraImportObject {
     // Fire off to the dirivitve hook to get the primary dsid's.
     $hook_output = array();
     foreach ($models as $key => $value) {
-      $lowered_model = str_replace(":", "_", $value);
+      $model_name_replacements = array(":","-");
+      $lowered_model = strtolower(str_replace($model_name_replacements, "_", $value));
       // Invoke _islandora_derivative hook for primary DSID's.
       $data = module_invoke_all("$lowered_model" . '_islandora_derivative');
       islandora_as_renderable_array($data);


### PR DESCRIPTION
The audio content model name includes "-" and has upper case characters that break the hook call to create derivatives.
