### PR TITLE
Batch Importing Zip file with marcxml of more than 30 - 50 entries fails

### DIFF
--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -185,9 +185,9 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected static $transformPath = '';
 
   /**
-   *  Function to initialize the static paths for various xsl 
+   * Function to initialize the static paths for various xsl 
    */
-  public static function initialize_paths() {
+  public static function initializePaths() {
 
     if (self::$transform_path == '') {
 
@@ -225,7 +225,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     parent::__construct($source);
     $this->pidNamespace = $this->source['pid_namespace'];
     $this->contentModel = (array) $this->source['content_model'];
-    self::initialize_paths();
+    self::initializePaths();
     $this->skeleton = islandora_get_tuque_connection()->repository->constructObject('temp:pid');
     $this->skeleton->models = $this->contentModel;
   }
@@ -448,7 +448,7 @@ EOXML;
    * Implements the PHP magic method __wakeup.
    */
   public function __wakeup() {
-    static::initialize_paths();
+    static::initializePaths();
   }
 
   /**

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -190,8 +190,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     if(self::$transform_path==''){
 
 	self::$transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
-	watchdog("islandora_importer","PATH IN INITIALIZE ".self::$transform_path);
-
+ 	
 	if(self::$MARC2MODS=='') self::$MARC2MODS = self::$transform_path."/MARC21slim2MODS3-4.xsl";
 
 	if(self::$DC2MODS=='') self::$DC2MODS = self::$transform_path."/simpleDC2MODS.xsl";
@@ -408,13 +407,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
         // wrappers that come out of the XSL output before setting the contents.
         // As documented, Islandora does not support multiple records within
         // a single MARC collection wrapper.
-        // $transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
-        //if(self::$MARC2MODS==''){ 
 
-	//	watchdog('islandora_importer', "reinitializing paths because of XSL VALUE => ".self::$MARC2MODS );		
-	//	self::initialize_paths();
-
-	// }
 	$transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
 	
         $this->mods = $this->cleanupMARC($transformed_marc);
@@ -444,6 +437,12 @@ EOXML;
     return $this->mods;
   }
 
+  /**
+  *  This function is the php magic function to reconstruct the file paths of xsl which were stored in the 
+  *  static variables. This simply calls initialize_paths method once more to initialize the paths.
+  *  
+  *  This method will be called when we unserialize this object after fetching it from the database.
+  */
   public function __wakeup(){
 
 	self::initialize_paths();

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -440,10 +440,8 @@ EOXML;
   }
 
   /**
-   *  This function is the php magic function to reconstruct the file paths of xsl which were stored in the 
-   *  static variables. This simply calls initialize_paths method once more to initialize the paths.
-   *  
-   *  This method will be called when we unserialize this object after fetching it from the database.
+   *   Implements the PHP magic method __wakeup 
+   *
    */
   public function __wakeup() {
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -423,7 +423,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
         // wrappers that come out of the XSL output before setting the contents.
         // As documented, Islandora does not support multiple records within
         // a single MARC collection wrapper.
-	$transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
+        $transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
 	
         $this->mods = $this->cleanupMARC($transformed_marc);
       }
@@ -453,8 +453,7 @@ EOXML;
   }
 
   /**
-   *   Implements the PHP magic method __wakeup 
-   *
+   * Implements the PHP magic method __wakeup 
    */
   public function __wakeup() {
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -236,7 +236,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
    * @see IslandoraImportObjectInterface::getOne()
    */
   public static function getOne(&$info) {
-  
     $record = array(
       'pid_namespace' => $info['pid_namespace'],
       'file' => $info['file'],

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -218,6 +218,10 @@ class ZipBatchImportObject extends IslandoraImportObject {
     $this->contentModel = (array) $this->source['content_model'];
 
     self::initialize_paths();
+
+    $this->skeleton = islandora_get_tuque_connection()->repository->constructObject('temp:pid');
+
+    $this->skeleton->models = $this->contentModel;
        
   }
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -189,16 +189,16 @@ class ZipBatchImportObject extends IslandoraImportObject {
 	
     if(self::$transform_path==''){
 
-	self::$transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
+      self::$transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
  	
-	if(self::$MARC2MODS=='') self::$MARC2MODS = self::$transform_path."/MARC21slim2MODS3-4.xsl";
+      if(self::$MARC2MODS=='') self::$MARC2MODS = self::$transform_path."/MARC21slim2MODS3-4.xsl";
 
-	if(self::$DC2MODS=='') self::$DC2MODS = self::$transform_path."/simpleDC2MODS.xsl";
+      if(self::$DC2MODS=='') self::$DC2MODS = self::$transform_path."/simpleDC2MODS.xsl";
 
-	if(self::$DWC2DC=='') self::$DWC2DC = self::$transform_path."/dwc_to_dc.xsl";
+      if(self::$DWC2DC=='') self::$DWC2DC = self::$transform_path."/dwc_to_dc.xsl";
 
-	if(self::$MADS2DC=='') self::$MADS2DC = self::$transform_path."/mads_to_dc.xsl";
-     }
+      if(self::$MADS2DC=='') self::$MADS2DC = self::$transform_path."/mads_to_dc.xsl";
+    }
 
   }
 
@@ -411,7 +411,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
         // wrappers that come out of the XSL output before setting the contents.
         // As documented, Islandora does not support multiple records within
         // a single MARC collection wrapper.
-
 	$transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
 	
         $this->mods = $this->cleanupMARC($transformed_marc);
@@ -449,7 +448,7 @@ EOXML;
   */
   public function __wakeup(){
 
-	self::initialize_paths();
+    self::initialize_paths();
 
   }
   /**

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -185,7 +185,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected static $transformPath = '';
 
   /**
-   * Function to initialize the static paths for various xsl 
+   * Function to initialize the static paths for various xsl.
    */
   public static function initializePaths() {
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -189,7 +189,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
    */
   public static function initializePaths() {
 
-    if (self::$transform_path == '') {
+    if (self::$transformPath == '') {
 
       self::$transformPath = drupal_get_path('module', 'zip_importer') . '/xsl';
 

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -185,16 +185,14 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected static $transformPath = '';
 
   /**
-   *  Function to initialize the static paths for various xsl
-   *  
+   *  Function to initialize the static paths for various xsl 
    */
-
   public static function initialize_paths(){
-	
+
     if (self::$transform_path == '') {
 
       self::$transformPath = drupal_get_path('module', 'zip_importer') . '/xsl';
- 	
+
       if (self::$MARC2MODS == '' ) {
         self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl"; 
       }
@@ -211,7 +209,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
         self::$MADS2DC = self::$transformPath . "/mads_to_dc.xsl";
       }
     }
-
   }
 
   /**

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -178,26 +178,25 @@ class ZipBatchImporter extends IslandoraBatchImporter {
 class ZipBatchImportObject extends IslandoraImportObject {
 
   protected $mods;
-  protected static $MARC2MODS ='';
+  protected static $MARC2MODS = '';
   protected static $DC2MODS = '';
   protected static $DWC2DC = '';
   protected static $MADS2DC = '';
-
-  protected static $transform_path = '';
+  protected static $transformPath = '';
 
   public static function initialize_paths(){
 	
     if(self::$transform_path==''){
 
-      self::$transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
+      self::$transformPath = drupal_get_path('module', 'zip_importer') . '/xsl';
  	
-      if(self::$MARC2MODS=='') self::$MARC2MODS = self::$transform_path."/MARC21slim2MODS3-4.xsl";
+      if (self::$MARC2MODS == '') self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl";
 
-      if(self::$DC2MODS=='') self::$DC2MODS = self::$transform_path."/simpleDC2MODS.xsl";
+      if (self::$DC2MODS == '') self::$DC2MODS = self::$transformPath . "/simpleDC2MODS.xsl";
 
-      if(self::$DWC2DC=='') self::$DWC2DC = self::$transform_path."/dwc_to_dc.xsl";
+      if (self::$DWC2DC == '') self::$DWC2DC = self::$transformPath . "/dwc_to_dc.xsl";
 
-      if(self::$MADS2DC=='') self::$MADS2DC = self::$transform_path."/mads_to_dc.xsl";
+      if (self::$MADS2DC == '') self::$MADS2DC = self::$transformPath . "/mads_to_dc.xsl";
     }
 
   }
@@ -441,16 +440,17 @@ EOXML;
   }
 
   /**
-  *  This function is the php magic function to reconstruct the file paths of xsl which were stored in the 
-  *  static variables. This simply calls initialize_paths method once more to initialize the paths.
-  *  
-  *  This method will be called when we unserialize this object after fetching it from the database.
-  */
-  public function __wakeup(){
+   *  This function is the php magic function to reconstruct the file paths of xsl which were stored in the 
+   *  static variables. This simply calls initialize_paths method once more to initialize the paths.
+   *  
+   *  This method will be called when we unserialize this object after fetching it from the database.
+   */
+  public function __wakeup() {
 
     self::initialize_paths();
 
   }
+
   /**
    * Generate DC to describe the imported data.
    *

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -178,10 +178,30 @@ class ZipBatchImporter extends IslandoraBatchImporter {
 class ZipBatchImportObject extends IslandoraImportObject {
 
   protected $mods;
-  protected static $MARC2MODS;
-  protected static $DC2MODS;
-  protected static $DWC2DC;
-  protected static $MADS2DC;
+  protected static $MARC2MODS ='';
+  protected static $DC2MODS = '';
+  protected static $DWC2DC = '';
+  protected static $MADS2DC = '';
+
+  protected static $transform_path = '';
+
+  public static function initialize_paths(){
+	
+    if(self::$transform_path==''){
+
+	self::$transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
+	watchdog("islandora_importer","PATH IN INITIALIZE ".self::$transform_path);
+
+	if(self::$MARC2MODS=='') self::$MARC2MODS = self::$transform_path."/MARC21slim2MODS3-4.xsl";
+
+	if(self::$DC2MODS=='') self::$DC2MODS = self::$transform_path."/simpleDC2MODS.xsl";
+
+	if(self::$DWC2DC=='') self::$DWC2DC = self::$transform_path."/dwc_to_dc.xsl";
+
+	if(self::$MADS2DC=='') self::$MADS2DC = self::$transform_path."/mads_to_dc.xsl";
+     }
+
+  }
 
   /**
    * An AbstractObject for use in calling hooks... Should *NOT* be ingested.
@@ -197,14 +217,9 @@ class ZipBatchImportObject extends IslandoraImportObject {
     parent::__construct($source);
     $this->pidNamespace = $this->source['pid_namespace'];
     $this->contentModel = (array) $this->source['content_model'];
-    $transform_path = drupal_get_path('module', 'zip_importer') . '/xsl';
-    self::$MARC2MODS = "$transform_path/MARC21slim2MODS3-4.xsl";
-    self::$DC2MODS = "$transform_path/simpleDC2MODS.xsl";
-    self::$DWC2DC = "$transform_path/dwc_to_dc.xsl";
-    self::$MADS2DC = "$transform_path/mads_to_dc.xsl";
 
-    $this->skeleton = islandora_get_tuque_connection()->repository->constructObject('temp:pid');
-    $this->skeleton->models = $this->contentModel;
+    self::initialize_paths();
+       
   }
 
   /**
@@ -213,6 +228,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
    * @see IslandoraImportObjectInterface::getOne()
    */
   public static function getOne(&$info) {
+  
     $record = array(
       'pid_namespace' => $info['pid_namespace'],
       'file' => $info['file'],
@@ -392,7 +408,15 @@ class ZipBatchImportObject extends IslandoraImportObject {
         // wrappers that come out of the XSL output before setting the contents.
         // As documented, Islandora does not support multiple records within
         // a single MARC collection wrapper.
-        $transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
+        // $transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
+        //if(self::$MARC2MODS==''){ 
+
+	//	watchdog('islandora_importer', "reinitializing paths because of XSL VALUE => ".self::$MARC2MODS );		
+	//	self::initialize_paths();
+
+	// }
+	$transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
+	
         $this->mods = $this->cleanupMARC($transformed_marc);
       }
       elseif ($this->isDC($xml)) {
@@ -420,6 +444,11 @@ EOXML;
     return $this->mods;
   }
 
+  public function __wakeup(){
+
+	self::initialize_paths();
+
+  }
   /**
    * Generate DC to describe the imported data.
    *

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -448,9 +448,7 @@ EOXML;
    * Implements the PHP magic method __wakeup.
    */
   public function __wakeup() {
-
-    self::initialize_paths();
-
+    static::initialize_paths();
   }
 
   /**

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -184,19 +184,32 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected static $MADS2DC = '';
   protected static $transformPath = '';
 
+  /**
+   *  Function to initialize the static paths for various xsl
+   *  
+   */
+
   public static function initialize_paths(){
 	
-    if(self::$transform_path==''){
+    if (self::$transform_path == '') {
 
       self::$transformPath = drupal_get_path('module', 'zip_importer') . '/xsl';
  	
-      if (self::$MARC2MODS == '') self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl";
+      if (self::$MARC2MODS == '' ) {
+        self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl"; 
+      }
 
-      if (self::$DC2MODS == '') self::$DC2MODS = self::$transformPath . "/simpleDC2MODS.xsl";
+      if (self::$DC2MODS == '') {
+        self::$DC2MODS = self::$transformPath . "/simpleDC2MODS.xsl";
+      }
 
-      if (self::$DWC2DC == '') self::$DWC2DC = self::$transformPath . "/dwc_to_dc.xsl";
+      if (self::$DWC2DC == '') {
+        self::$DWC2DC = self::$transformPath . "/dwc_to_dc.xsl";
+      }
 
-      if (self::$MADS2DC == '') self::$MADS2DC = self::$transformPath . "/mads_to_dc.xsl";
+      if (self::$MADS2DC == '') {
+        self::$MADS2DC = self::$transformPath . "/mads_to_dc.xsl";
+      }
     }
 
   }

--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -187,14 +187,14 @@ class ZipBatchImportObject extends IslandoraImportObject {
   /**
    *  Function to initialize the static paths for various xsl 
    */
-  public static function initialize_paths(){
+  public static function initialize_paths() {
 
     if (self::$transform_path == '') {
 
       self::$transformPath = drupal_get_path('module', 'zip_importer') . '/xsl';
 
-      if (self::$MARC2MODS == '' ) {
-        self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl"; 
+      if (self::$MARC2MODS == '') {
+        self::$MARC2MODS = self::$transformPath . "/MARC21slim2MODS3-4.xsl";
       }
 
       if (self::$DC2MODS == '') {
@@ -225,13 +225,9 @@ class ZipBatchImportObject extends IslandoraImportObject {
     parent::__construct($source);
     $this->pidNamespace = $this->source['pid_namespace'];
     $this->contentModel = (array) $this->source['content_model'];
-
     self::initialize_paths();
-
     $this->skeleton = islandora_get_tuque_connection()->repository->constructObject('temp:pid');
-
     $this->skeleton->models = $this->contentModel;
-       
   }
 
   /**
@@ -421,7 +417,6 @@ class ZipBatchImportObject extends IslandoraImportObject {
         // As documented, Islandora does not support multiple records within
         // a single MARC collection wrapper.
         $transformed_marc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MARC2MODS));
-	
         $this->mods = $this->cleanupMARC($transformed_marc);
       }
       elseif ($this->isDC($xml)) {
@@ -450,7 +445,7 @@ EOXML;
   }
 
   /**
-   * Implements the PHP magic method __wakeup 
+   * Implements the PHP magic method __wakeup.
    */
   public function __wakeup() {
 


### PR DESCRIPTION
Hello

In our installation of islandora we tried to import batch of more than 5000 marc xml file as a zip file and we found that the objects were getting created in fedora but with invalid fields. When i debugged it , found that the database entries were getting created but found that the xsl passed in for the method to serialize ::runXSLTransform was empty. After lot of debugging i found the reason why it is happening.
It goes like this : Objects are created -> stored in the database after serializing -> but only object properties not static properties are stored. -> (in case of less than 30 objects, it is unserialized quite early before the garbage collector clears the variables etc.) -> hence every thing works well. -> but when it is the case with more than 200(my test case) -> it is stored in the database and unserialized and calling the objects method getMODS -> there is no static variable for the paths. -> hence the conversion to MODS fails.

So i moved the static initializers to a static function called initialize_paths and called it from the wakeup magic method and the constructor - so that it will be available when the batch op tries to getMODS from it.

By doing this we have fixed the issue we were facing with the marc xml imports of big zip files.
