### PR TITLE
ISLANDORA-1522 global UUID setting enforcement

### DIFF
--- a/includes/importer.inc
+++ b/includes/importer.inc
@@ -131,8 +131,9 @@ abstract class IslandoraBatchImporter extends IslandoraBatchPreprocessor impleme
     if (empty($this->context['results']['pid_cache'])) {
       // Get enough PIDs for half of the remaining items.
       // (plus one, so we'll always get at least one).
-      $this->context['results']['pid_cache'] = (array) $tuque->api->m->getNextPid(
+      $this->context['results']['pid_cache'] = (array) $tuque->repository->getNextIdentifier(
         $namespace,
+        NULL,
         intval((($this->context['sandbox']['max'] - $this->context['sandbox']['progress']) / 2) + 1)
       );
     }


### PR DESCRIPTION
Addresses https://jira.duraspace.org/browse/ISLANDORA-1522

Makes use of repository getNextIdentifier() instead of calling directly
api-m method to allow our UUID enforcement to be applied

Depends on:

https://github.com/Islandora/islandora/pull/634
https://github.com/Islandora/tuque/pull/128 

Similar to:
https://github.com/Islandora/islandora_batch/pull/76
