### PR TITLE
Change type to avoid warning.

### DIFF
--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -277,7 +277,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
     }
 
     $mimetype = $mime_detect->getMimetype($name);
-    $dsid = FALSE;
+    $dsid = array();
     // Determine which stream this should be, Gather together all
     // non optional datastream ids.
     foreach ($dsids as $ds => $info) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1644
# What does this Pull Request do?

When zip importing a zip (such as the one on the ticket) to a content model where a primary datastream is not matched a warning will be thrown as it's possible a boolean is being attempted to be foreached.
# How should this be tested?

Go to the book collection.
ZIP import the attached zip.
Note how there is a foreach warning thrown.

**Tagging:** @Islandora/7-x-1-x-committers as I am the maintainer.
## Thanks!

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
