### PR TITLE
Fix PHP error thrown with using importer in PHP7

### DIFF
--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -494,13 +494,6 @@ EOXML;
     if (isset($this->source['object_info']['xml'])) {
       $xml_filename = $this->source['object_info']['xml'];
       $xml = $this->getXML();
-
-      if ($this->isDWC($datastream)) {
-        $dsid = 'DWC';
-      }
-      elseif ($this->isMADS($datastream)) {
-        $dsid = 'MADS';
-      }
     }
     else {
       return "$dsid datastream";


### PR DESCRIPTION
**JIRA Ticket**: 

https://jira.duraspace.org/browse/ISLANDORA-1906

# What does this Pull Request do?

When importing a file with the zip importer using PHP7 I am getting:
`TypeError: SimpleXMLElement::__construct() expects parameter 1 to be string, array given in SimpleXMLElement->__construct().`
![screen shot 2017-02-07 at 5 56 35 pm](https://cloud.githubusercontent.com/assets/569437/22720033/da011790-ed7e-11e6-96b8-e3cf5ac57b81.png)

It appears to me that the removed lines have always been giving an error since we are passing an array instead of a string, since this code was merged here:
https://github.com/Islandora/islandora_importer/pull/45

In PHP5 SimpleXML doesn't pop type errors, but in PHP7 it does. Because we were passing in an array, these if statements would never evaluate to true, since the simplexml element would be empty when constructed with an array.

I don't believe these lines are necessary, as the DSID should get set here:
https://github.com/Islandora/islandora_importer/blob/7.x/modules/zip_importer/includes/importer.inc#L330-L342

And not need to be set by these lines.

# What's new?

Removed two if statements that were causing issues in PHP7.

# How should this be tested?

Test batch with PHP5, see it work. 
Test batch with PHP7, see it fail before patch. See it pass after patch. 
Test batch with MADs and DWC data streams, see that it works after patch.

# Interested parties
@DiegoPino @adam-vessey 