### PR TITLE
Support zip import of RDF data with title in dc:title element

### DIFF
--- a/modules/zip_importer/includes/importer.inc
+++ b/modules/zip_importer/includes/importer.inc
@@ -142,8 +142,8 @@ class ZipBatchImporter extends IslandoraBatchImporter {
     $zip = new ZipArchive();
     if (($error = $zip->open(drupal_realpath($file->uri))) !== TRUE) {
       drupal_set_message(t('Error opening the provided Zip file.  Code: %code', array(
-            '%code' => $error,
-          )));
+        '%code' => $error,
+      )));
       return;
     }
 
@@ -182,6 +182,7 @@ class ZipBatchImportObject extends IslandoraImportObject {
   protected static $DC2MODS = '';
   protected static $DWC2DC = '';
   protected static $MADS2DC = '';
+  protected static $RDF2DC = '';
   protected static $transformPath = '';
 
   /**
@@ -207,6 +208,10 @@ class ZipBatchImportObject extends IslandoraImportObject {
 
       if (self::$MADS2DC == '') {
         self::$MADS2DC = self::$transformPath . "/mads_to_dc.xsl";
+      }
+
+      if (self::$RDF2DC == '') {
+        self::$RDF2DC = variable_get('zip_importer_path_rdf_to_dc', self::$transformPath . "/rdf_to_dc.xsl");
       }
     }
   }
@@ -341,6 +346,13 @@ class ZipBatchImportObject extends IslandoraImportObject {
           $mimetype = 'application/xml';
         }
 
+        elseif ($this->isRDF($this->getXML())) {
+          // For RDF file, set datastream to RDF and skips the detection.
+          $do_determine_dsid_and_mimetype = FALSE;
+          $dsid = 'RDF';
+          $mimetype = 'application/rdf+xml';
+        }
+
         else {
           // XML streams are handled via the parent implementation,
           // (via get_{mods,dc}()) so let's go to the next item.
@@ -397,6 +409,40 @@ class ZipBatchImportObject extends IslandoraImportObject {
     }
 
     return $to_return;
+  }
+
+  // Override parent getTitle().
+  public function getTitle() {
+    
+    if ($this->title === NULL) {
+      // RDF
+      $xml = $this->getXML();
+      if ($this->isRDF($xml)) {
+        $rdf_doc = new DOMDocument();
+        $rdf_doc->loadXML($xml);
+        $xpath = new DOMXPath($rdf_doc);
+        $xpath->registerNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+        $xpath->registerNamespace("dcterms", "http://purl.org/dc/terms/");
+        $xpath->registerNamespace("wgs84", "http://www.w3.org/2003/01/geo/wgs84_pos#");
+        $xpath->registerNamespace("schema", "http://schema.org");
+        $xpath->registerNamespace("dc", "http://purl.org/dc/elements/1.1/");
+
+        $this->title = $xpath->evaluate('string(//dc:title)');
+      }
+      else {
+        $mods = $this->getMODS();
+        if ($mods) {
+          $mods_doc = new DOMDocument();
+          $mods_doc->loadXML($mods);
+          $mods_xpath = new DOMXPath($mods_doc);
+          $mods_xpath->registerNamespace('m', 'http://www.loc.gov/mods/v3');
+
+          $this->title = $mods_xpath->evaluate('string(//m:mods/m:titleInfo/m:title/text())');
+        }
+      }
+    }
+
+    return $this->title;
   }
 
   /**
@@ -469,6 +515,10 @@ EOXML;
       }
       elseif ($this->isMADS($xml)) {
         $this->dc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$MADS2DC));
+      }
+      // Added by jh
+      elseif ($this->isRDF($xml)) {
+        $this->dc = static::runXSLTransform(array('input' => $xml, 'xsl' => self::$RDF2DC));
       }
       // Otherwise, call the parent implementation (transform from MODS).
       if (empty($this->dc)) {
@@ -570,6 +620,14 @@ EOXML;
    */
   protected function isDC($xml) {
     return $this->getLocalNameOfRootElement($xml) == 'dc';
+  }
+
+  /**
+   * Checks if the given file content is actually a RDF document.
+   */
+  protected function isRDF($xml) {
+    $localNameOfRootElement = $this->getLocalNameOfRootElement($xml);
+    return strtolower($localNameOfRootElement) == 'rdf';
   }
 
   /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2171

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?
The University of Canterbury QuakeStudies archive uses Islandora with RDF datastreams instead of MODS. To allow bulk ingest via the Zip importer, I've modified the importer code to handle an RDF datastream. The RDF should define a dc:title element. An XSLT to map from RDF to DC is required (not included).

A brief description of what the intended result of the PR will be and/or what problem it solves.
Content models using RDF instead of MODS can be imported via the Zip importer.

# What's new?
* Add ability to import objects with RDF datastreams via Zip importer.

# How should this be tested?
1. Create RDF XML files to match several JPEG images, e.g.
`<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <dc:title>Test photograph 1 (BULK INGEST)</dc:title>
</rdf:RDF>`
2. Provide an XSLT to convert RDF to DC, e.g.
`<xsl:stylesheet version="1.0"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:dcterms="http://purl.org/dc/terms/"
    xmlns:srw_dc="info:srw/schema/1/dc-schema"
    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:schema="http://schema.org"
    xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
    xmlns:qsr="http://quakestudies.canterbury.ac.nz"
    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
    <xsl:output method="xml" indent="yes"/>
    <xsl:template match="/">
        <xsl:for-each select="rdf:RDF">
            <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
                       xmlns:dc="http://purl.org/dc/elements/1.1/"
                       xmlns:dcterms="http://purl.org/dc/terms/"
                       xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">
                <xsl:apply-templates/>
            </oai_dc:dc>
        </xsl:for-each>
    </xsl:template>
    <xsl:template match="dc:*">
        <xsl:copy>
            <xsl:value-of select="."/>
        </xsl:copy>
    </xsl:template>
    <!-- suppress all else:-->
    <xsl:template match="*"/>
</xsl:stylesheet>`
3. Zip the XML and images.
4. Set the path to the XSLT via the zip_importer_path_rdf_to_dc variable, e.g. via 
`drush -u 1 vset --yes zip_importer_path_rdf_to_dc "sites/all/modules/custom/quakestudies_rdf/transforms/quakestudies_object_to_dc.xsl"`
4. Use the Zip import to ingest the images via the Zip file.
5. Result should be images imported with appropriate RDF and DC datastreams.

A description of what steps someone could take to:
See above.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
Zip importer docs will need to be updated.

# Interested parties
@Islandora/7-x-1-x-committers
